### PR TITLE
[Fix] column ordered and strided data vertex errors

### DIFF
--- a/src/array.hpp
+++ b/src/array.hpp
@@ -512,14 +512,14 @@ public:
   bool swap(ind_t i, ind_t a, ind_t b);
   std::vector<T> to_std() const;
   T* ptr();
-  T* ptr(const ind_t i0);
+  T* ptr(ind_t i0);
   template<class ... Subs, class=std::enable_if_t<polystar::utils::are_same<ind_t,Subs...>::value, void>>
-  T* ptr(const ind_t i0, Subs... subscripts);
+  T* ptr(ind_t i0, Subs... subscripts);
   T* ptr(const shape_t& partial_subscript);
   const T* ptr() const;
-  const T* ptr(const ind_t i0) const;
+  const T* ptr(ind_t i0) const;
   template<class ... Subs, class=std::enable_if_t<polystar::utils::are_same<ind_t,Subs...>::value, void>>
-  const T* ptr(const ind_t i0, Subs... subscripts) const;
+  const T* ptr(ind_t i0, Subs... subscripts) const;
   const T* ptr(const shape_t& partial_subscript) const;
   T& val(const ind_t i0);
   template<class ... Subs, class=std::enable_if_t<polystar::utils::are_same<ind_t,Subs...>::value, void>>
@@ -532,8 +532,12 @@ public:
   const T& val(const shape_t& partial_subscript) const;
   template<typename I> const T& val(std::initializer_list<I> l) const;
 
+  std::vector<T> to_std(ind_t i0) const;
+
   Array<T> contiguous_copy() const;
   Array<T> contiguous_row_ordered_copy() const;
+  //! Return the first-dimension Array with index i0
+  Array<T> contiguous_row_ordered_copy(ind_t i0) const;
   Array<T> squeeze() const;
   Array<T> squeeze(const ind_t dim) const;
   Array<T> slice(const ind_t i0) const;

--- a/src/array.hpp
+++ b/src/array.hpp
@@ -521,7 +521,6 @@ public:
   template<class ... Subs, class=std::enable_if_t<polystar::utils::are_same<ind_t,Subs...>::value, void>>
   const T* ptr(ind_t i0, Subs... subscripts) const;
   const T* ptr(const shape_t& partial_subscript) const;
-  const T* cptr(ind_t i0) const;
   T& val(const ind_t i0);
   template<class ... Subs, class=std::enable_if_t<polystar::utils::are_same<ind_t,Subs...>::value, void>>
   T& val(const ind_t i0, Subs... subscripts);

--- a/src/array.hpp
+++ b/src/array.hpp
@@ -521,6 +521,7 @@ public:
   template<class ... Subs, class=std::enable_if_t<polystar::utils::are_same<ind_t,Subs...>::value, void>>
   const T* ptr(ind_t i0, Subs... subscripts) const;
   const T* ptr(const shape_t& partial_subscript) const;
+  const T* cptr(ind_t i0) const;
   T& val(const ind_t i0);
   template<class ... Subs, class=std::enable_if_t<polystar::utils::are_same<ind_t,Subs...>::value, void>>
   T& val(const ind_t i0, Subs... subscripts);

--- a/src/array.tpp
+++ b/src/array.tpp
@@ -1061,11 +1061,6 @@ const T& Array<T>::val(std::initializer_list<I> l) const {
 }
 
 template<class T>
-const T* Array<T>::cptr(const ind_t i0) const {
-  return contiguous_row_ordered_copy(i0).ptr(0u);
-}
-
-template<class T>
 std::vector<T> Array<T>::to_std(const ind_t i0) const {
   auto a0 = contiguous_row_ordered_copy(i0);
   // a0 is contiguous (and either a new copy or a view into this data)

--- a/src/array.tpp
+++ b/src/array.tpp
@@ -1061,6 +1061,11 @@ const T& Array<T>::val(std::initializer_list<I> l) const {
 }
 
 template<class T>
+const T* Array<T>::cptr(const ind_t i0) const {
+  return contiguous_row_ordered_copy(i0).ptr(0u);
+}
+
+template<class T>
 std::vector<T> Array<T>::to_std(const ind_t i0) const {
   auto a0 = contiguous_row_ordered_copy(i0);
   // a0 is contiguous (and either a new copy or a view into this data)

--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -520,6 +520,8 @@ public:
   const T* ptr(ind_t i0) const;
   const T* ptr(ind_t i0, ind_t j0) const;
   const T* ptr(const shape_t& partial_subscript) const;
+  const T* cptr(ind_t i0) const;
+
   T& val(ind_t i0);
   T& val(ind_t i0, ind_t j0);
   T& val(const shape_t& partial_subscript);

--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -520,7 +520,6 @@ public:
   const T* ptr(ind_t i0) const;
   const T* ptr(ind_t i0, ind_t j0) const;
   const T* ptr(const shape_t& partial_subscript) const;
-  const T* cptr(ind_t i0) const;
 
   T& val(ind_t i0);
   T& val(ind_t i0, ind_t j0);

--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -48,7 +48,7 @@ public:
   using sItr = SubIt2<ind_t>;
   using aItr = Array2It<T>;
 protected:
-  T*    _data;     //! A (possilby shared) raw pointer
+  T*    _data;     //! A (possibly shared) raw pointer
   ind_t _num;      //! The number of elements stored under the raw pointer
   ind_t _shift;    //! A linear shift to where our subscript indexing begins (_data+shift)[subscript]
   bool  _own;      //! Whether we need to worry about memory management of the pointer
@@ -86,6 +86,10 @@ public:
   [[nodiscard]] ind_t size(const ind_t dim) const {
     assert(dim < 2);
     return _shape[dim];
+  }
+  [[nodiscard]] ind_t stride(const ind_t dim) const {
+    assert(dim < 2);
+    return _stride[dim];
   }
   [[nodiscard]] shape_t shape() const {return _shape;}
   [[nodiscard]] shape_t stride() const {return _stride;}
@@ -525,8 +529,12 @@ public:
   const T& val(const shape_t& partial_subscript) const;
   template<class I> const T& val(std::initializer_list<I> l) const;
 
+  std::vector<T> to_std(ind_t i0) const;
+
   Array2<T> contiguous_copy() const;
   Array2<T> contiguous_row_ordered_copy() const;
+  //! Return the first-dimension Array with index i0
+  Array2<T> contiguous_row_ordered_copy(ind_t i0) const;
 
   Array2<T> abs() const;
   template<class R> bool is_permutation(const Array2<R>& other, T Ttol=T(0), R Rtol=R(0), int tol=1) const;

--- a/src/array2.tpp
+++ b/src/array2.tpp
@@ -1186,16 +1186,19 @@ T* Array2<T>::ptr(const shape_t& p){
 
 template<class T>
 const T* Array2<T>::ptr(const ind_t i0) const {
+  debug_update("Consider replacing this by Array2::to_std(i0)");
   assert(i0 < _shape[0]);
   return _data + ij2l_d(i0, 0u);
 }
 template<class T>
 const T* Array2<T>::ptr(const ind_t i0, const ind_t j0) const {
+  debug_update("Consider replacing this by Array2::val(i0, j0)");
   assert(i0 < _shape[0] && j0 < _shape[1]);
   return _data + ij2l_d(i0, j0);
 }
 template<class T>
 const T* Array2<T>::ptr(const shape_t& p) const {
+  debug_update("Consider replacing this by Array2::val(shape_t p)");
   assert(p[0]<_shape[0] && p[1]<_shape[1]);
   return _data + s2l_d(p);
 }
@@ -1246,6 +1249,19 @@ const T& Array2<T>::val(std::initializer_list<I> l) const {
 }
 
 template<class T>
+std::vector<T> Array2<T>::to_std(const ind_t i0) const {
+//  info_update("Extract index ", i0, " from ", to_string(), "expected ", to_string(i0));
+  auto a0 = contiguous_row_ordered_copy(i0);
+//  info_update("produced ", a0.to_string());
+  std::vector<T> out;
+  out.reserve(a0.numel());
+  for (auto x: a0.valItr()){
+    out.push_back(x);
+  }
+  return out;
+}
+
+template<class T>
 Array2<T> Array2<T>::contiguous_copy() const {
   if (this->is_contiguous()) return Array2<T>(*this);
   Array2<T> out(_shape, this->calculate_stride(_shape));
@@ -1258,6 +1274,24 @@ Array2<T> Array2<T>::contiguous_row_ordered_copy() const {
   if (this->is_row_ordered() && this->is_contiguous()) return Array2<T>(*this);
   Array2<T> out(_shape, this->calculate_stride(_shape));
   for (auto x : this->subItr()) out[x] = (*this)[x];
+  return out;
+}
+
+template<class T>
+Array2<T> Array2<T>::contiguous_row_ordered_copy(const ind_t i0) const {
+  if (is_row_ordered() && is_contiguous()) {
+    view(i0);
+  }
+  shape_t st{{1u, 1u}};
+  for (size_t i=st.size()-1; i--;) st[i] = st[i+1]*_shape[i+1];
+  auto sh = _shape;
+  sh[0] = 1u;
+  Array2<T> out(sh, st);
+  for (auto x : SubIt2<ind_t>(sh)) {
+    auto y = x;
+    y[0] = i0;
+    out[x] = (*this)[y];
+  }
   return out;
 }
 

--- a/src/array2.tpp
+++ b/src/array2.tpp
@@ -1249,10 +1249,13 @@ const T& Array2<T>::val(std::initializer_list<I> l) const {
 }
 
 template<class T>
+const T * Array2<T>::cptr(const ind_t i0) const {
+  // Ensure that _data is C-contiguous, possibly via a view, then return a pointer
+  return contiguous_row_ordered_copy(i0).ptr(0u);
+}
+template<class T>
 std::vector<T> Array2<T>::to_std(const ind_t i0) const {
-//  info_update("Extract index ", i0, " from ", to_string(), "expected ", to_string(i0));
   auto a0 = contiguous_row_ordered_copy(i0);
-//  info_update("produced ", a0.to_string());
   std::vector<T> out;
   out.reserve(a0.numel());
   for (auto x: a0.valItr()){

--- a/src/array2.tpp
+++ b/src/array2.tpp
@@ -1249,11 +1249,6 @@ const T& Array2<T>::val(std::initializer_list<I> l) const {
 }
 
 template<class T>
-const T * Array2<T>::cptr(const ind_t i0) const {
-  // Ensure that _data is C-contiguous, possibly via a view, then return a pointer
-  return contiguous_row_ordered_copy(i0).ptr(0u);
-}
-template<class T>
 std::vector<T> Array2<T>::to_std(const ind_t i0) const {
   auto a0 = contiguous_row_ordered_copy(i0);
   std::vector<T> out;

--- a/src/array_functions.hpp
+++ b/src/array_functions.hpp
@@ -173,11 +173,11 @@ ARRAY_LATVEC_BINARY_OP(/)
     polystar::ind_t oO = (1u == aN) ? bN : aN;
     auto oarray = L<S>(oO, 3u); // row-ordered contiguous
     if (1u == aN){
-      for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.to_std(0), b.to_std(j));
+      for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.cptr(0), b.cptr(j));
     } else if (1u == bN) {
-      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.to_std(j), b.to_std(0));
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.cptr(j), b.cptr(0));
     } else {
-      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.to_std(j), b.to_std(j));
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.cptr(j), b.cptr(j));
     }
     return oarray;
   }
@@ -192,11 +192,11 @@ ARRAY_LATVEC_BINARY_OP(/)
     polystar::ind_t oO = (1u == aN) ? bN : aN;
     auto oarray = L<S>(oO, 1u); // row-ordered contiguous
     if (1u == aN) {
-      for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.to_std(0), b.to_std(j));
+      for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.cptr(0), b.cptr(j));
     } else if (1u == bN) {
-      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.to_std(j), b.to_std(0));
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.cptr(j), b.cptr(0));
     } else {
-      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.to_std(j), b.to_std(j));
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.cptr(j), b.cptr(j));
     }
     return oarray;
   }
@@ -242,15 +242,16 @@ dot(const A<T>& a, const A<R>& b) {
   assert( a.size(1) == b.size(1) );
   assert( a.is_row_ordered() && b.is_row_ordered() && a.is_contiguous() && b.is_contiguous() );
   polystar::ind_t aN=a.size(0), bN=b.size(0);
+  auto d = a.size(1);
   assert( 1u==aN || 1u==bN || aN==bN );
   polystar::ind_t oO = (1u == aN) ? bN : aN;
   auto oarray = A<S>(oO, 1u);
   if (1u==aN){
-    for (polystar::ind_t i=0; i<bN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(a.to_std(0), b.to_std(i));
+    for (polystar::ind_t i=0; i<bN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(d, a.cptr(0), b.cptr(i));
   } else if (1u==bN) {
-    for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(a.to_std(i), b.to_std(0));
+    for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(d, a.cptr(i), b.cptr(0));
   } else {
-    for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(a.to_std(i), b.to_std(i));
+    for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(d, a.cptr(i), b.cptr(i));
   }
   return oarray;
 }
@@ -259,7 +260,7 @@ template<class T, class R, class M, template<class> class A, class S=std::common
 std::enable_if_t<bothArrays<T,A,R,A>, S>
 same_lattice_dot(const A<R>& x, const A<T>& y, const std::array<M,9>& metric){
   std::array<S,3> tmp{0,0,0};
-  utils::mul_mat_vec(tmp.data(), metric.data(), x.to_std(0));
+  utils::mul_mat_vec(tmp.data(), metric.data(), x.cptr(0));
   S out{0};
   for (int i=0; i<3; ++i) out += tmp[i] * static_cast<S>(y[i]);
 //  verbose_update("metric x ", x.to_string(0), " = ", tmp , "; dot with ", y.to_string(0), " = ", out);
@@ -581,7 +582,7 @@ from_xyz_like(const A<T>& lv, const B<T>& b){
   B<S> coords(b.shape());
   auto x = b.shape();
   x.back() = 0u;
-  for (auto i: b.subItr(x)) utils::multiply_matrix_vector(coords.ptr(i), inv_xyz, b.to_std(i));
+  for (auto i: b.subItr(x)) utils::multiply_matrix_vector(coords.ptr(i), inv_xyz.data(), b.cptr(i));
   return A<S>(lv.type(), lat, coords);
 }
 

--- a/src/array_functions.hpp
+++ b/src/array_functions.hpp
@@ -168,19 +168,16 @@ ARRAY_LATVEC_BINARY_OP(/)
   cross(const L<T>& a, const L<R>& b) {
     using namespace polystar::utils;
     assert( a.size(1) == 3 && b.size(1)==3 );
-    assert( a.is_row_ordered() && b.is_row_ordered() && a.is_contiguous() && b.is_contiguous() );
     polystar::ind_t aN=a.size(0), bN=b.size(0);
     assert( 1u==aN || 1u==bN || aN==bN );
     polystar::ind_t oO = (1u == aN) ? bN : aN;
     auto oarray = L<S>(oO, 3u); // row-ordered contiguous
-    if (1u == aN || 1u == bN){
-      if (1u == aN){
-        for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.ptr(0), b.ptr(j));
-      } else {
-        for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.ptr(j), b.ptr(0));
-      }
+    if (1u == aN){
+      for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.to_std(0), b.to_std(j));
+    } else if (1u == bN) {
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.to_std(j), b.to_std(0));
     } else {
-      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.ptr(j), b.ptr(j));
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,3>(oarray.ptr(j), a.to_std(j), b.to_std(j));
     }
     return oarray;
   }
@@ -190,19 +187,16 @@ ARRAY_LATVEC_BINARY_OP(/)
   cross2d(const L<T>& a, const L<R>& b) {
     using namespace polystar::utils;
     assert( a.size(1) == 2 && b.size(1)== 2 );
-    assert( a.is_row_ordered() && b.is_row_ordered() && a.is_contiguous() && b.is_contiguous() );
     polystar::ind_t aN=a.size(0), bN=b.size(0);
     assert( 1u==aN || 1u==bN || aN==bN );
     polystar::ind_t oO = (1u == aN) ? bN : aN;
     auto oarray = L<S>(oO, 1u); // row-ordered contiguous
-    if (1u == aN || 1u == bN){
-      if (1u == aN){
-        for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.ptr(0), b.ptr(j));
-      } else {
-        for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.ptr(j), b.ptr(0));
-      }
+    if (1u == aN) {
+      for (polystar::ind_t j=0; j<bN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.to_std(0), b.to_std(j));
+    } else if (1u == bN) {
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.to_std(j), b.to_std(0));
     } else {
-      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.ptr(j), b.ptr(j));
+      for (polystar::ind_t j=0; j<aN; ++j) vector_cross<S,T,R,2>(oarray.ptr(j), a.to_std(j), b.to_std(j));
     }
     return oarray;
   }
@@ -247,18 +241,16 @@ dot(const A<T>& a, const A<R>& b) {
   using namespace polystar::utils;
   assert( a.size(1) == b.size(1) );
   assert( a.is_row_ordered() && b.is_row_ordered() && a.is_contiguous() && b.is_contiguous() );
-  polystar::ind_t aN=a.size(0), bN=b.size(0), d=a.size(1);
+  polystar::ind_t aN=a.size(0), bN=b.size(0);
   assert( 1u==aN || 1u==bN || aN==bN );
   polystar::ind_t oO = (1u == aN) ? bN : aN;
   auto oarray = A<S>(oO, 1u);
-  if (1u==aN || 1u==bN) {
-    if (1u==aN){
-      for (polystar::ind_t i=0; i<bN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(d, a.ptr(0), b.ptr(i));
-    } else {
-      for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(d, a.ptr(i), b.ptr(0));
-    }
+  if (1u==aN){
+    for (polystar::ind_t i=0; i<bN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(a.to_std(0), b.to_std(i));
+  } else if (1u==bN) {
+    for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(a.to_std(i), b.to_std(0));
   } else {
-    for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(d, a.ptr(i), b.ptr(i));
+    for (polystar::ind_t i=0; i<aN; ++i) oarray.val(i,0) = vector_dot<S,T,R>(a.to_std(i), b.to_std(i));
   }
   return oarray;
 }
@@ -267,7 +259,7 @@ template<class T, class R, class M, template<class> class A, class S=std::common
 std::enable_if_t<bothArrays<T,A,R,A>, S>
 same_lattice_dot(const A<R>& x, const A<T>& y, const std::array<M,9>& metric){
   std::array<S,3> tmp{0,0,0};
-  utils::mul_mat_vec(tmp.data(), 3u, metric.data(), x.ptr(0));
+  utils::mul_mat_vec(tmp.data(), metric.data(), x.to_std(0));
   S out{0};
   for (int i=0; i<3; ++i) out += tmp[i] * static_cast<S>(y[i]);
 //  verbose_update("metric x ", x.to_string(0), " = ", tmp , "; dot with ", y.to_string(0), " = ", out);
@@ -444,7 +436,7 @@ operator*(const std::array<R,9>& m, const L<T>& a){
   L<S> out(a.type(), a.lattice(), ashape);
   ashape.back() = 0;
   for (auto x : a.subItr(ashape))
-    polystar::utils::multiply_matrix_vector<S,R,T,3>(out.ptr(x), m.data(), a.ptr(x));
+    polystar::utils::multiply_matrix_vector<S,R,T,3>(out.ptr(x), m.data(), a.to_data(x));
   return out;
 }
 
@@ -589,7 +581,7 @@ from_xyz_like(const A<T>& lv, const B<T>& b){
   B<S> coords(b.shape());
   auto x = b.shape();
   x.back() = 0u;
-  for (auto i: b.subItr(x)) utils::multiply_matrix_vector(coords.ptr(i), inv_xyz.data(), b.ptr(i));
+  for (auto i: b.subItr(x)) utils::multiply_matrix_vector(coords.ptr(i), inv_xyz, b.to_std(i));
   return A<S>(lv.type(), lat, coords);
 }
 

--- a/src/utilities.tpp
+++ b/src/utilities.tpp
@@ -41,8 +41,15 @@ template<typename T, typename R, typename S, size_t N, size_t I, size_t M> void 
   for (size_t i=0;i<N;i++) for (size_t j=0;j<M;j++) for (size_t k=0;k<I;k++) C[i*M+j] += T(A[i*I+k]*B[k*M+j]);
 }
 template<typename T, typename R, typename S, size_t N> void multiply_matrix_matrix(T *C, const R *A, const S *B){ multiply_arrays<T,R,S,N,N,N>(C,A,B); }
-template<typename T, typename R, typename S, size_t N> void multiply_matrix_vector(T *C, const R *A, const S *b){ multiply_arrays<T,R,S,N,N,1>(C,A,b); }
-template<typename T, typename R, typename S, size_t N> void multiply_vector_matrix(T *C, const R *a, const S *B){ multiply_arrays<T,R,S,1,N,N>(C,a,B); }
+template<typename T, typename R, typename S, size_t N> void multiply_matrix_vector(T *C, const R *A, const S *v){ multiply_arrays<T,R,S,N,N,1>(C,A,v); }
+template<typename T, typename R, typename S, size_t N> void multiply_vector_matrix(T *C, const R *v, const S *B){ multiply_arrays<T,R,S,1,N,N>(C,v,B); }
+
+template<typename T, typename R, typename S, size_t N> void multiply_matrix_vector(T * C, const std::vector<R> & A, const std::vector<S> & v){
+  multiply_arrays<T,R,S,N,N,1>(C, A.data(), v.data());
+}
+template<typename T, typename R, typename S, size_t N> void multiply_matrix_vector(T * C, const R * A, const std::vector<S> & v){
+  multiply_arrays<T,R,S,N,N,1>(C, A, v.data());
+}
 
 
 // array multiplication specialization for non-complex * complex arrays.
@@ -210,6 +217,14 @@ template<typename S, typename T, typename R>
 S vector_dot(const size_t n, const T* a, const R* b){
   S out = 0;
   for (size_t i=0; i<n; ++i) out += static_cast<S>(a[i])*static_cast<S>(b[i]);
+  return out;
+}
+template<typename S, typename T, typename R>
+S vector_dot(const std::vector<T>& a, const std::vector<R>& b){
+  S out = 0;
+  for (size_t i=0; i<a.size(); ++i) {
+    out += static_cast<S>(a[i]) * static_cast<S>(b[i]);
+  }
   return out;
 }
 

--- a/wrap/_array.hpp
+++ b/wrap/_array.hpp
@@ -141,11 +141,13 @@ namespace polystar {
       throw std::runtime_error("polystar::Array2 objects require 2D input!");
     std::array<ind_t,2> shape{{0,0}}, stride{{0,0}};
     auto num = polystar::utils::s2u<ind_t,pybind11::ssize_t>(info.size);
+
     for (pybind11::ssize_t i=0; i<info.ndim; ++i){
       shape[i] = static_cast<ind_t>(info.shape[i]);
       stride[i] = static_cast<ind_t>(info.strides[i]/sizeof(T));
       if (shape[i]*stride[i] > num) num = shape[i]*stride[i];
     }
+
     T* ptr = (T*) info.ptr;
     bool own_memory{false}; // we NEVER own the memory coming from Python
     bool py_mutable{!info.readonly};

--- a/wrap/tests/test_polygon.py
+++ b/wrap/tests/test_polygon.py
@@ -27,3 +27,71 @@ class PolygonTestCase(TestCase):
         self.assertEqual(len(net.wires()), 2)
         for wire in net.wires():
             self.assertEqual(len(wire), 3, "The wire of a triangle has three entries")
+
+    def memory_layout_checks(self, vertices, border, area):
+        from polystar import Polygon
+        poly = Polygon(vertices)
+        poly_area = poly.area
+        self.assertAlmostEqual(poly_area, area)
+        self.assertAlmostEqual(Polygon(vertices, border).area, area)
+
+    def test_vertices_memory_layout_auto_conversion(self):
+        from numpy import array, ascontiguousarray, asfortranarray, allclose
+        v_list = [[0, 0.1], [0, 0.001], [1, 0.001], [1, 0.1]]
+        border = [0, 1, 2, 3]
+        area = (0.1 - 0.001) * (1 - 0)
+        # pybind11 converts nested lists as expected
+        self.memory_layout_checks(v_list, border, area)
+
+    def test_vertices_memory_layout_numpy_array_conversion(self):
+        from numpy import array, ascontiguousarray, asfortranarray, allclose
+        v_list = [[0, 0.1], [0, 0.001], [1, 0.001], [1, 0.1]]
+        border = [0, 1, 2, 3]
+        area = (0.1 - 0.001) * (1 - 0)
+        # numpy.array provides C contiguous arrays
+        v_array = array(v_list)
+        self.assertTrue(v_array.flags['C_CONTIGUOUS'])
+        self.memory_layout_checks(v_array, border, area)
+
+    def test_vertices_memory_layout_numpy_ascontiguousarray(self):
+        from numpy import array, ascontiguousarray, asfortranarray, allclose
+        v_list = [[0, 0.1], [0, 0.001], [1, 0.001], [1, 0.1]]
+        border = [0, 1, 2, 3]
+        area = (0.1 - 0.001) * (1 - 0)
+        # we can also be explicit
+        v_c = ascontiguousarray(v_list)
+        v_array = array(v_list)
+        self.assertTrue(v_c.flags['C_CONTIGUOUS'])
+        self.assertTrue(allclose(v_c, v_array))
+        self.memory_layout_checks(v_c, border, area)
+
+    def test_vertices_memory_layout_numpy_ascfortranarray(self):
+        from numpy import array, ascontiguousarray, asfortranarray, allclose
+        v_list = [[0, 0.1], [0, 0.001], [1, 0.001], [1, 0.1]]
+        border = [0, 1, 2, 3]
+        area = (0.1 - 0.001) * (1 - 0)
+        # providing column ordered (FORTRAN style) data should not make any difference
+        v_f = asfortranarray(v_list)
+        v_array = array(v_list)
+        self.assertTrue(v_f.flags['F_CONTIGUOUS'])
+        self.assertTrue(allclose(v_f, v_array))
+        self.memory_layout_checks(v_f, border, area)
+
+    def test_vertices_memory_layout_numpy_strided(self):
+        from numpy import array, ascontiguousarray, asfortranarray, allclose
+        v_list = [[0, 0.1], [0, 0.001], [1, 0.001], [1, 0.1]]
+        border = [0, 1, 2, 3]
+        area = (0.1 - 0.001) * (1 - 0)
+        # we should also be able to provide strided arrays
+        v_extended = array([[v[0], -1, v[1]] for v in v_list])
+        v_stride = v_extended[:, ::2]
+        v_array = array(v_list)
+        self.assertFalse(v_stride.flags['C_CONTIGUOUS'])
+        self.assertFalse(v_stride.flags['F_CONTIGUOUS'])
+        self.assertTrue(allclose(v_stride, v_array))
+        self.memory_layout_checks(v_stride, border, area)
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()

--- a/wrap/tests/test_polystar.py
+++ b/wrap/tests/test_polystar.py
@@ -13,7 +13,7 @@ class PolystarTestCase(TestCase):
             import_module('polystar')
         except ModuleNotFoundError as exception:
             self.fail(f"Importing the polystar module failed because it was not found with message\n\t{exception}")
-        except:
-            self.fail(f"Importing the polystar module failed without known reason")
+        except ImportError as exception:
+            self.fail(f"Importing the polystar module failed with message\n{exception}")
 
 


### PR DESCRIPTION
Fixes #1 by implementing new `std::vector` data accessors (which must copy data in all cases) and then switching `cross` and `cross2` to use the new `.to_std(index)` methods instead of directly using `.ptr(index)` which only gave the correct data if the underlying data was C-contiguous.

The copy could be avoided in the C-contiguous case by using `array.contiguous_row_ordered_copy(index).ptr(0)` since the first method returns a view if the data is already C-contiguous.
Perhaps a new method could make this easier, e.g., `.const_ptr(index)`, since all cases where the data might be non-C-contiguous are (hopefully) via the `const T* ptr(ind_t i0) const` overloads (and it's probably not a good idea to silently insert a copy into the existing methods).