### PR TITLE
[Add] transform and skew methods for Polygon

### DIFF
--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -675,7 +675,7 @@ Array2<S> operator* (const std::array<T,N> & matrix, const Array2<R> & vectors){
     throw std::runtime_error("Expected " + std::to_string(n) + " square matrix but provided "
                              + std::to_string(N) + " element array");
   }
-  auto v = vectors.contiguous_row_ordered_copy();
+  auto v = vectors.contiguous_row_ordered_copy().decouple();
   std::vector<T> tmp(n);
   for (ind_t i=0; i<v.size(0u); ++i){
     utils::mul_mat_vec(tmp.data(), n, matrix.data(), v.ptr(i));

--- a/src/array2.hpp
+++ b/src/array2.hpp
@@ -668,6 +668,22 @@ public:
   T* operator->() {return &(array[*subit]);}
 };
 
+template<class T, class R, size_t N, class S = std::common_type_t<T,R>>
+Array2<S> operator* (const std::array<T,N> & matrix, const Array2<R> & vectors){
+  auto n = vectors.size(1u);
+  if (N != n * n) {
+    throw std::runtime_error("Expected " + std::to_string(n) + " square matrix but provided "
+                             + std::to_string(N) + " element array");
+  }
+  auto v = vectors.contiguous_row_ordered_copy();
+  std::vector<T> tmp(n);
+  for (ind_t i=0; i<v.size(0u); ++i){
+    utils::mul_mat_vec(tmp.data(), n, matrix.data(), v.ptr(i));
+    std::copy(tmp.data(), tmp.data()+n, v.ptr(i));
+  }
+  return v;
+}
+
 
 #include "array2.tpp"
 } // end namespace polystar

--- a/src/polygon_poly.hpp
+++ b/src/polygon_poly.hpp
@@ -118,6 +118,19 @@ namespace polystar::polygon{
     Poly<T,A> centre() const {return {vertices_ - centroid(), wires_};}
     Poly<T,A> translate(const A<T>& v) const {return {vertices_ + v, wires_};}
 
+    Poly<T,A> transform(const std::array<T,4>& matrix) const {return {matrix * vertices_, wires_};}
+    Poly<T,A> skew(T factor, int source, int sink) const {
+      if (source == sink) {
+        throw std::logic_error("polystar::polygon::Poly::skew: source can not equal sink");
+      }
+      if (source < 0 || source > 1 || sink < 0 || sink > 1) {
+        throw std::logic_error("polystar::polygon::Poly::skew: source and sink must be in bounds");
+      }
+      std::array<T, 4> matrix{{1, 0, 0, 1}};
+      matrix[source * 2 + sink] = factor;
+      return transform(matrix);
+    }
+
     template<class R, template<class> class B>
       [[nodiscard]] std::vector<bool> border_contains(const B<R>& x) const {
       return wires_.border_contains(x, vertices_);

--- a/wrap/_polygon.hpp
+++ b/wrap/_polygon.hpp
@@ -68,6 +68,20 @@ void define_polygon(py::class_<A> & cls){
     return p.to_svg(std::make_optional(fill), std::make_optional(stroke));
   }, py::kw_only(), "fill"_a="none", "stroke"_a="black");
 
+  cls.def("transform", [](const A & p, py::array_t<T>& pyv){
+    auto info = pyv.request();
+    if (info.ndim != 2 || info.size != 4 || info.shape[0] != 2 || info.shape[1] != 2) {
+      throw std::runtime_error("polystar::Polygon::transform takes a 2x2 array");
+    }
+    std::array<T, 4> matrix;
+    matrix[0] = ((T *) info.ptr)[0];
+    matrix[1] = ((T *) info.ptr)[info.strides[1]/info.itemsize];
+    matrix[2] = ((T *) info.ptr)[info.strides[0]/info.itemsize];
+    matrix[3] = ((T *) info.ptr)[(info.strides[0] + info.strides[1])/info.itemsize];
+    return p.transform(matrix);
+  }, "matrix"_a);
+  cls.def("skew", &A::skew);
+
 // overloaded operations:
   cls.def("__eq__", [](const A& p, const A& o){return p == o;});
   cls.def("__neq__", [](const A& p, const A& o){return p != o;});


### PR DESCRIPTION
- Adds a `transform` method in the C++ side that takes a row-ordered flattened 2x2 matrix and applies it to the vertices of a `polystar::polygon::Poly` object, returning a new object.
- Adds a `skew` method in the C++ side that sets one of the off diagonal terms of an otherwise identity 2x2 matrix and then uses `transform` to produce the skewed polygon.
- Adds both methods to the Python interface, with `transform` accepting 2x2 numpy arrays (converted automatically from, e.g., a list of lists `[[1, 2], [0, 1]]`).