### PR TITLE
Better polygon intersection

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ list(APPEND CXX_SOURCES
   bitmap_show.cpp
   polygon_wire.cpp
   polygon_wires.cpp
+  polygon_clipping.cpp
   hdf_interface.cpp
 )
 

--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -1108,11 +1108,14 @@ namespace polystar {
     return true;
   }
 
-  /* \brief Find the intersection of two line segments
+  /** \brief Find the intersection of two line segments
    *
    * An intersection point exists if the two line segments are not parallel. That intersection point is 'valid' if
    * it is within *both* line segments.
    *
+   * \note
+   * The inclusivity refers to the end points of the `first` or `second` **edge**, not the first or second point on
+   * one of the edges!
    * */
   enum class end_type {both, first, second, neither};
 
@@ -1140,10 +1143,15 @@ namespace polystar {
           auto t0 = static_cast<double>(dot(qp, r).val(0,0)) / r2;
           auto sr = static_cast<double>(dot(s, r).val(0,0));
           auto t1 = t0 + sr / r2;
-          if (sr < 0) std::swap(t0, t1);
+          if (sr < 0) {
+            std::swap(t0, t1);
+            std::swap(lok, rok);
+          }
           auto st0{std::sqrt(t0)};
           auto st1{std::sqrt(t1)};
-          bool inside{(0 < t0 && t1 < 1 && t0 < t1) || (lok && (0 < t0 && t0 < 1 && t1 == 1))};
+          // the second edge is inside the first edge
+          bool inside{(0 < t0 && t1 < 1 && t0 < t1) || (lok && (0 <= t0 && t1 <= 1 && t0 < t1))};
+          // the first edge is inside the second edge
           bool outside{(t0 < 0 && t1 > 1) || (rok && (t0 <= 0 && t1 >= 1))};
           if (inside || outside) {
             // collinear *and* overlap

--- a/src/polygon.hpp
+++ b/src/polygon.hpp
@@ -2,7 +2,6 @@
 #define POLYSTAR_POLYGON_HPP
 
 #include "polygon_poly.hpp"
-
-#include "polygon_network.tpp"
+#include "polygon_last.hpp"
 
 #endif

--- a/src/polygon_clipping.cpp
+++ b/src/polygon_clipping.cpp
@@ -1,0 +1,93 @@
+#include "polygon_clipping.hpp"
+
+using namespace polystar::polygon;
+using namespace polystar::polygon::clip;
+
+
+std::vector<Wire> VertexLists::intersection_wires() const {
+  std::vector<Wire> combined;
+  if (A.is_empty() && B.is_empty()) return combined;
+  if (A.is_empty()) return {B.wire(On::B)};
+  if (B.is_empty()) return {A.wire(On::A)};
+  // Use the Weiler-Atherton algorithm to combine the two wires
+  // https://en.wikipedia.org/wiki/Weiler%E2%80%93Atherton_clipping_algorithm
+  // https://liorsinai.github.io/mathematics/2023/09/30/polygon-clipping.html
+
+  // Walk around wire B, looking for an intersection with wire A that is pointing into A
+  auto v = B.first();
+  do {
+    v->visited(true);
+    if (v->type() == Type::entry){
+      // We have found an intersection point, now walk around wire B until we find the exit point
+      Wire wire;
+      auto start = v;
+      do {
+        v->visited(true);
+        wire.push_back(v->value());
+        v = v->next(On::B);
+      } while (v != start && v->type() != Type::exit);
+      // If we found the exit point, keep walking around A until we find the entry point again
+      if (v != start) {
+        v = v->next(On::A);
+        while (v != start){
+          v->visited(true);
+          wire.push_back(v->value());
+          v = v->next(On::A);
+        }
+      }
+      combined.push_back(wire);
+    }
+    // Fast-forward over the already-visited vertices
+    while (v->visited() && v != B.first()) v = v->next(On::B);
+  } while (v != B.first());
+
+  return combined;
+}
+
+std::vector<Wire> VertexLists::union_wires() const {
+  std::vector<Wire> combined;
+  if (A.is_empty() && B.is_empty()) return combined;
+  if (A.is_empty()) return {B.wire(On::B)};
+  if (B.is_empty()) return {A.wire(On::A)};
+  // Use the Weiler-Atherton algorithm to combine the two wires
+  // https://en.wikipedia.org/wiki/Weiler%E2%80%93Atherton_clipping_algorithm
+
+  // Walk around wire B, looking for an intersection with wire A that is pointing into A
+  auto v = B.first();
+  Wire wire;
+  On on = On::B;
+  do {
+    v->visited(true);
+    wire.push_back(v->value());
+    if (v->type() == Type::entry) on = On::A;
+    else if (v->type() == Type::exit) on = On::B;
+    v = v->next(on);
+  } while (!v->visited() && v != B.first());
+  combined.push_back(wire);
+
+  // Walk around wire B again, looking for unvisited intersection vertices (which should be holes)
+  v = B.first();
+  do {
+    if (v->type() == Type::entry && !v->visited()){
+      Wire hole;
+      auto start = v;
+      do {
+        v->visited(true);
+        hole.push_back(v->value());
+        v = v->prev(On::B);
+      } while (v != start && v->type() != Type::exit);
+      if (v != start) {
+        v = v->prev(On::A);
+        while (v != start){
+          v->visited(true);
+          hole.push_back(v->value());
+          v = v->prev(On::A);
+        }
+      }
+      combined.push_back(hole);
+    }
+    v = v->next(On::B);
+  } while (v != B.first());
+
+  return combined;
+}

--- a/src/polygon_clipping.cpp
+++ b/src/polygon_clipping.cpp
@@ -91,3 +91,24 @@ std::vector<Wire> VertexLists::union_wires() const {
 
   return combined;
 }
+
+std::string polystar::polygon::clip::to_string(Type type){
+  switch (type){
+    case Type::unknown: return "?";
+    case Type::entry: return "v";
+    case Type::exit: return "^";
+    case Type::original: return "o";
+    case Type::edge: return "-";
+    default: return "!";
+  }
+}
+
+std::string polystar::polygon::clip::to_string(On on){
+  switch (on){
+    case On::neither: return "_";
+    case On::A: return "A";
+    case On::B: return "B";
+    case On::both: return "+";
+    default: return "!";
+  }
+}

--- a/src/polygon_clipping.hpp
+++ b/src/polygon_clipping.hpp
@@ -216,25 +216,16 @@ namespace polystar::polygon::clip
            * otherwise, pick the vertex which is closest to a1.
            * */
           auto a1 = v.view(edge_a.first);
-          std::cout << v.to_string(edge_a.first) << " -- " << v.to_string(edge_a.second) << " & ";
-          std::cout << v.to_string(edge_b.first) << " -- " << v.to_string(edge_b.second) << " \n";
-          std::cout << "at was " << at.to_string();
           if (at.row_is(cmp::eq, a1).any()){
             at = at.extract(at.row_is(cmp::neq, a1));
           } else {
             auto diff = norm(at - a1); // a (2, 1) Array2
             at = at.extract(diff.row_is(cmp::eq, diff.min(0u)));
           }
-          std::cout << "at is now " << at.to_string();
         }
         if (valid){
           //  1. Add it to the list of all vertices
           auto index = v.size(0);
-          if (at.size(0u) > 1) {
-            std::cout << v.to_string(edge_a.first) << " -- " << v.to_string(edge_a.second) << " & ";
-            std::cout << v.to_string(edge_b.first) << " -- " << v.to_string(edge_b.second) << " \n";
-            std::cout << at.to_string();
-          }
           auto match = v.row_is(cmp::eq, at);
           if (match.any()){
             // the intersection point is already in the list of vertices

--- a/src/polygon_clipping.hpp
+++ b/src/polygon_clipping.hpp
@@ -1,0 +1,118 @@
+#pragma once
+#include "polygon_poly.hpp"
+#include "polygon_wire.hpp"
+
+namespace polystar::polygon::clip
+{
+  using ind_t = polystar::ind_t;
+
+  enum class Type {unknown, entry, exit, original};
+  enum class On {neither, A, B, both};
+
+  class Vertex{
+  public:
+    using ptr = std::shared_ptr<Vertex>;
+  private:
+    ind_t _value{0};
+    Type _type = Type::unknown;
+    bool _visited = false;
+  protected:
+    ptr prev_A, next_A, prev_B, next_B;
+
+  public:
+    Vertex() = default;
+    explicit Vertex(ind_t i, Type type = Type::original) : _value(i), _type(type) {}
+
+    /// \brief Construct a 'normal' vertex
+    Vertex(ind_t i, On on, const ptr& prev, const ptr& next): _value(i), _type(Type::original) {
+      if (on == On::A) {
+        prev_A = prev;
+        next_A = next;
+      } else if (on == On::B) {
+        prev_B = prev;
+        next_B = next;
+      }
+    }
+
+    /// \param Construct a common (intersection) vertex
+    Vertex(ind_t i, Type type, Vertex * prev_A, Vertex * next_A, Vertex * prev_B, Vertex * next_B)
+      : _value(i), _type(type), prev_A(prev_A), next_A(next_A), prev_B(prev_B), next_B(next_B) {}
+
+    [[nodiscard]] ind_t value() const { return _value; }
+    [[nodiscard]] Type type() const { return _type; }
+    [[nodiscard]] bool visited() const { return _visited; }
+    void visited(bool v) { _visited = v; }
+
+    [[nodiscard]] bool is_A() const { return next_A != nullptr && prev_A != nullptr; }
+    [[nodiscard]] bool is_B() const { return next_B != nullptr && prev_B != nullptr; }
+    [[nodiscard]] bool is_Both() const { return is_A() && is_B(); }
+
+    void prev(On on, const ptr& v) {
+      if (on == On::A || on == On::both) prev_A = v;
+      if (on == On::B || on == On::both) prev_B = v;
+    }
+    void next(On on, const ptr& v) {
+      if (on == On::A || on == On::both) next_A = v;
+      if (on == On::B || on == On::both) next_B = v;
+    }
+    [[nodiscard]] ptr next(On on) const {
+      if (on == On::A) return next_A;
+      if (on == On::B) return next_B;
+      return nullptr;
+    }
+    [[nodiscard]] ptr prev(On on) const {
+      if (on == On::A) return prev_A;
+      if (on == On::B) return prev_B;
+      return nullptr;
+    }
+
+  };
+
+  class VertexList{
+    Vertex::ptr head;
+
+  public:
+    VertexList(const polystar::polygon::Wire & p, On on) {
+      if (p.empty()) return;
+      head = std::make_shared<Vertex>(p[0]);
+      head->next(on, head);
+      auto prev = head;
+      for (ind_t i = 1; i < p.size(); ++i) {
+        auto v = std::make_shared<Vertex>(p[i]);
+        // insert the new vertex into the list
+        v->prev(on, prev);
+        v->next(on, prev->next(on));
+        prev->next(on, v);
+        // move to the next vertex
+        prev = v;
+      }
+      head->prev(on, prev);
+    }
+
+    [[nodiscard]] polystar::polygon::Wire wire(On on) const {
+      Wire res;
+      auto v = head;
+      if (v == nullptr) return res;
+      do {
+        res.push_back(v->value());
+        v = v->next(on);
+      } while (v != head);
+      return res;
+    }
+
+    [[nodiscard]] bool is_empty() const { return head == nullptr || (head == head->next(On::A) && head == head->next(On::B));}
+    [[nodiscard]] Vertex::ptr first() const { return head; }
+  };
+
+  class VertexLists{
+    VertexList A, B;
+
+  public:
+    VertexLists(const polystar::polygon::Wire & a, const polystar::polygon::Wire & b): A(a, On::A), B(b, On::B) {}
+
+    [[nodiscard]] std::vector<Wire> intersection_wires() const;
+    [[nodiscard]] std::vector<Wire> union_wires() const;
+  };
+
+  // TODO Implement the line segment intersection finder to setup the VertexLists object for two Poly objects
+}

--- a/src/polygon_last.hpp
+++ b/src/polygon_last.hpp
@@ -1,5 +1,14 @@
 #ifndef POLYSTAR_POLYGON_NETWORK_TPP
 #define POLYSTAR_POLYGON_NETWORK_TPP
+#include "polygon_network.hpp"
+#include "polygon_wire.hpp"
+
+/** \file Implements Network methods that depend on Wire
+ *
+ * The two classes have interdependent methods, Wire includes Network
+ * so Network _can't_ include Wire.
+ * This solution works, even if it is somewhat convoluted.
+ */
 
 //static
 //std::tuple<std::array<polystar::ind_t,3>, std::array<polystar::ind_t,3>>

--- a/src/polygon_network.hpp
+++ b/src/polygon_network.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include "graph.hpp"
 #include "svg.hpp"
+#include "geometry.hpp"
 
 namespace polystar::polygon {
   template<class W, class T, template<class> class A>

--- a/src/polygon_poly.hpp
+++ b/src/polygon_poly.hpp
@@ -491,6 +491,7 @@ namespace polystar::polygon{
     // Construct the dual doubly-linked lists of vertex indices
     auto lists = clip::VertexLists(new_wa, new_wb);
     v = clip::weiler_atherton(v, lists);
+//    std::cout << "Result of Weiler-Atherton, vertices:\n" << v.to_string() << "lists:\n" << lists << "\n";
     auto wires = lists.union_wires();
     // the union wires returned vector is {border, hole0, hole1, ...}
     std::vector<Poly<T, A>> result;

--- a/src/polygon_poly.hpp
+++ b/src/polygon_poly.hpp
@@ -1,5 +1,12 @@
 #ifndef POLYSTAR_POLYGON_POLY_HPP
 #define POLYSTAR_POLYGON_POLY_HPP
+
+#ifndef POLYSTAR_POLYGON_HPP
+#pragma message("polygon_poly.hpp included without first including polygon.hpp"\
+                " Network defines missing"\
+)
+#endif
+
 #include <vector>
 #include <array>
 #include <optional>
@@ -96,7 +103,7 @@ namespace polystar::polygon{
     [[nodiscard]] bool operator!=(const Poly<T,A>& that) const {return is_not_approx(that);}
     [[nodiscard]] bool operator==(const Poly<T,A>& that) const {return !is_not_approx(that);}
 
-    Poly<T,A> operator+(const Poly<T,A>& that) const {return intersection(that);}
+    //Poly<T,A> operator+(const Poly<T,A>& that) const {return intersection(that);}
     Poly<T,A> combine(const Poly<T,A>& that, const T tol=T(0), const int dig=1) const {
       // combine vertices
       auto v = cat(0, vertices_, that.vertices());
@@ -107,12 +114,12 @@ namespace polystar::polygon{
       // look for overlapping wires now that vertex indexing has been modified
       return Poly<T,A>(v, remove_extraneous_wires(w));
     }
-    Poly<T,A> combine_all(const std::vector<Poly<T,A>> & others, const T tol=T(0), const int dig=1) const {
-      if (others.empty()) return *this;
-      auto out = intersection(others.front(), tol, dig);
-      for (auto ptr = others.begin()+1; ptr != others.end(); ++ptr) out = out.intersection(*ptr, tol, dig);
-      return out;
-    }
+//    Poly<T,A> combine_all(const std::vector<Poly<T,A>> & others, const T tol=T(0), const int dig=1) const {
+//      if (others.empty()) return *this;
+//      auto out = intersection(others.front(), tol, dig);
+//      for (auto ptr = others.begin()+1; ptr != others.end(); ++ptr) out = out.intersection(*ptr, tol, dig);
+//      return out;
+//    }
 
     Poly<T,A> mirror() const {return {T(-1) * vertices_, wires_.mirror()};}
     Poly<T,A> inverse() const {return {vertices_, wires_.inverse()};}
@@ -147,29 +154,32 @@ namespace polystar::polygon{
     template<class R, template<class> class B>
       [[nodiscard]] std::enable_if_t<isArray<R, B>, bool>
       intersects(const Poly<R, B> & that, const R tol=R(0), const int dig=1) const {
+      auto a = area();
+      if (approx_float::scalar(a, R(0), tol, tol, dig)) return false;
+      auto is_not_empty = [tol, dig, a](auto p){
+        auto pa = p.area();
+        return !approx_float::scalar(pa / (pa + a), R(0), tol, tol, dig);
+      };
       auto overlap = intersection(that, tol, dig);
-      if (!approx_float::scalar(overlap.area() / (area() + overlap.area()), R(0), tol, tol, dig)) {
-        return true;
-      }
-      return false;
+      return std::any_of(overlap.begin(), overlap.end(), is_not_empty);
     }
 
-    [[nodiscard]] Poly<T,A> intersection(const Poly<T,A>& that, T tol = T(0), int dig = 0) const {
+    [[nodiscard]] std::vector<Poly<T,A>> intersection(const Poly<T,A>& that, T tol = T(0), int dig = 0) const {
       // simple-case checks first: ignore the possibility of negative polygon inclusion?
       auto that_in_this = border_contains(that.vertices());
       if (std::all_of(that_in_this.begin(), that_in_this.end(), [](const auto x){return x;})) {
-        if (that.area() > T(0) && that.wires().wire_count() == 0) return *this;
-        return insert_hole(that.simplify(), tol, dig);
+        if (that.area() > T(0) && that.wires().wire_count() == 0) return {*this};
+        return {insert_hole(that.simplify(), tol, dig)};
       }
       auto this_in_that = that.border_contains(vertices_);
       if (std::all_of(this_in_that.begin(), this_in_that.end(), [](const auto x){return x;})) {
-        if (area() > T(0) && wires_.wire_count() == 0) return that;
-        return that.insert_hole(simplify(), tol, dig);
+        if (area() > T(0) && wires_.wire_count() == 0) return {that};
+        return {that.insert_hole(simplify(), tol, dig)};
       }
       if (wires_.wire_count() || that.wires().wire_count()){
-        return intersection(triangulate(), that.triangulate());
+        return networks_intersection(triangulate(), that.triangulate());
       }
-      return intersection(vertices_, wires_.border(), that.vertices(), that.wires().border());
+      return wires_intersection(vertices_, wires_.border(), that.vertices(), that.wires().border());
     }
 //    template<class R, template<class> class B>
 //    [[nodiscard]] std::enable_if_t<isArray<R,B>, Poly<T,A>> cut(const B<R>& a, const B<R>& b, const R tol=R(0), const int dig=1) const {
@@ -314,21 +324,37 @@ namespace polystar::polygon{
     template<class T, template<class> class A>
     bool
     could_not_overlap(const A<T> &va, const Wire &wa, const A<T> &vb, const Wire &wb) {
-      auto a_radius = wa.circumscribed_radius(va);
-      auto b_radius = wb.circumscribed_radius(vb);
-      auto a_centre = wa.centroid(va);
-      auto b_centre = wb.centroid(vb);
-      auto d = a_centre.distance(b_centre);
-      return d > a_radius + b_radius;
+      auto r = wa.circumscribed_radius(va) + wb.circumscribed_radius(vb);
+      auto v = wa.centroid(va) - wb.centroid(vb);
+      auto d2 = dot(v, v).val(0, 0);
+      return d2 > r * r;
     }
 
 
     template<class T, template<class> class A>
     bool
     contains(const A<T> &v0, const Wire &w0, const A<T> &v1, const Wire &w1) {
-      auto one_in_zero = w0.contains(v1.extract(w1), v0);
+      auto pts = v1.extract(w1);
+      auto one_in_zero = w0.contains(pts, v0);
       // if all are contained, then the whole is contained
       return std::all_of(one_in_zero.begin(), one_in_zero.end(), [](const auto x) { return x; });
+    }
+
+    template<class T, template<class> class A> bool
+    contains_or_on_border(const A<T> &v0, const Wire &w0, const A<T> &v1, const Wire &w1){
+      auto pts = v1.extract(w1);
+      auto in = w0.contains(pts, v0);
+      auto on = w0.is_on(pts, v0);
+      auto all_either = [](const auto & x, const auto & y){
+        return std::transform_reduce(x.begin(), x.end(), y.begin(), true,
+                                     /*reducer*/ [](const auto a, const auto b){return a && b;},
+                                     /*transformer*/ [](const auto a, const auto b){return a || b;}
+                                     );
+      };
+      auto any_in = std::any_of(in.begin(), in.end(), [](const auto x){return x;});
+      auto all_on = std::all_of(on.begin(), on.end(), [](const auto x){return x;});
+      // rounding errors can cause a point to be both in and on?!
+      return any_in && !all_on && all_either(in, on);
     }
   }
 
@@ -336,28 +362,34 @@ namespace polystar::polygon{
   /// \brief Find all intersection points for two polygon wires, then return their intersection polygons
   template<class T, template<class> class A>
   std::vector<Poly<T, A>>
-  intersection(const A<T> & va, const Wire & wa, const A<T> & vb, const Wire & wb){
+  wires_intersection(const A<T> & va, const Wire & wa, const A<T> & vb, const Wire & wb){
     // If the two polygons are too far apart, return nothing
     if (utils::could_not_overlap(va, wa, vb, wb)) return {};
-    // If all of A is inside B, return A
-    if (utils::contains(vb, wb, va, wa)) return {Poly<T, A>(va, wa)};
-    // If all of B is inside A, return b
-    if (utils::contains(va, wa, vb, wb)) return {Poly<T, A>(vb, wb)};
+    // If any of A is inside B and all of A is inside _or_ on the border of B, return A
+    if (utils::contains_or_on_border(vb, wb, va, wa)) {
+      return {Poly<T, A>(va, wa)};
+    }
+    // If any of B is inside A and all of B is inside _or_ on the border of A, return b
+    if (utils::contains_or_on_border(va, wa, vb, wb)) {
+      return {Poly<T, A>(vb, wb)};
+    }
     // Otherwise, find the intersection points:
-    // Combine the two sets of vertices into a single list
-    auto v = cat(0, va.extract(wa), vb.extract(wb));
+    // Combine the two sets of vertices into a single list, but keep only unique vertices
+    auto v = cat(0, va.extract(wa), vb.extract(wb)).unique();
     // Make the new wires for A and B, since we may have reduced or re-ordered their vertices:
     Wire new_wa, new_wb;
-    new_wa.resize(wa.size());
-    new_wb.resize(wb.size());
-    std::iota(new_wa.begin(), new_wa.end(), 0);
-    std::iota(new_wb.begin(), new_wb.end(), wa.size());
+    new_wa.reserve(wa.size());
+    new_wb.reserve(wb.size());
+    for (const auto & idx: wa){
+      new_wa.push_back(v.row_is(cmp::eq, va.view(idx)).first());
+    }
+    for (const auto & idx: wb){
+      new_wb.push_back(v.row_is(cmp::eq, vb.view(idx)).first());
+    }
     // Construct the dual doubly-linked lists of vertex indices
     auto lists = clip::VertexLists(new_wa, new_wb);
-    auto no_problems = clip::weiler_atherton(v, lists);
-    if (no_problems){
-      std::cerr << "Warning: " << no_problems << " problems found in the Weiler-Atherton algorithm" << std::endl;
-    }
+    v = clip::weiler_atherton(v, lists); // updates v with intersection points
+    std::cout << "Result of Weiler-Atherton, vertices:\n" << v.to_string() << "lists:\n" << lists << "\n";
     auto wires = lists.intersection_wires();
     std::vector<Poly<T, A>> result;
     result.reserve(wires.size());
@@ -371,22 +403,22 @@ namespace polystar::polygon{
   /// \brief Find the intersection of two polygons, triangulating if either has any holes
   template<class T, template<class> class A>
   std::vector<Poly<T, A>>
-  intersection(const Poly<T, A> & a, const Poly<T, A> & b) {
+  polygon_intersection(const Poly<T, A> & a, const Poly<T, A> & b) {
     if (a.wires().wire_count() || b.wires().wire_count()){
-      return intersection(a.triangulate(), b.triangulate());
+      return networks_intersection(a.triangulate(), b.triangulate());
     }
-    return intersection(a.vertices(), a.wires().border(), b.vertices(), b.wires().border());
+    return wires_intersection(a.vertices(), a.wires().border(), b.vertices(), b.wires().border());
   }
 
   /// \brief Find the intersection of two triangulated polygon networks by considering all pairs of triangles
   template<class T, template<class> class A, class W=Wire>
   std::vector<Poly<T, A>>
-  intersection(const Network<W, T, A> & a, const Network<W, T, A> & b) {
+  networks_intersection(const Network<W, T, A> & a, const Network<W, T, A> & b) {
     std::vector<Poly<T, A>> result;
     result.reserve(std::max(a.size(), b.size()));
     for (const auto & wa: a.wires()) {
       for (const auto & wb: b.wires()) {
-        auto ps = intersection(a.vertices(), wa, b.vertices(), wb);
+        auto ps = wires_intersection(a.vertices(), wa, b.vertices(), wb);
         for (const auto & p: ps) if (p.area()) result.push_back(p);
       }
     }
@@ -398,7 +430,7 @@ namespace polystar::polygon{
   /// \brief Find all intersection points for two polygon wires, then return their union polygons
   template<class T, template<class> class A>
   std::vector<Poly<T, A>>
-  union_polygons(const A<T> & va, const Wire & wa, const A<T> & vb, const Wire & wb){
+  wires_union(const A<T> & va, const Wire & wa, const A<T> & vb, const Wire & wb){
     // If the two polygons are too far apart, return both
     if (utils::could_not_overlap(va, wa, vb, wb)) return {{va, wa}, {vb, wb}};
     // If all of A is inside B, return B
@@ -408,19 +440,20 @@ namespace polystar::polygon{
     if (utils::contains(va, wa, vb, wb)) return {{va, wa}};
     // Otherwise, find the intersection points:
     // Combine the two sets of vertices into a single list
-    auto v = cat(0, va.extract(wa), vb.extract(wb));
+    auto v = cat(0, va.extract(wa), vb.extract(wb)).unique();
     // Make the new wires for A and B, since we may have reduced or re-ordered their vertices:
     Wire new_wa, new_wb;
-    new_wa.resize(wa.size());
-    new_wb.resize(wb.size());
-    std::iota(new_wa.begin(), new_wa.end(), 0);
-    std::iota(new_wb.begin(), new_wb.end(), wa.size());
+    new_wa.reserve(wa.size());
+    new_wb.reserve(wb.size());
+    for (const auto & idx: wa){
+      new_wa.push_back(v.row_is(cmp::eq, va.view(idx)).first());
+    }
+    for (const auto & idx: wb){
+      new_wb.push_back(v.row_is(cmp::eq, vb.view(idx)).first());
+    }
     // Construct the dual doubly-linked lists of vertex indices
     auto lists = clip::VertexLists(new_wa, new_wb);
-    auto no_problems = clip::weiler_atherton(v, lists);
-    if (no_problems){
-      std::cerr << "Warning: " << no_problems << " problems found in the Weiler-Atherton algorithm" << std::endl;
-    }
+    v = clip::weiler_atherton(v, lists);
     auto wires = lists.union_wires();
     // the union wires returned vector is {border, hole0, hole1, ...}
     std::vector<Poly<T, A>> result;
@@ -434,22 +467,22 @@ namespace polystar::polygon{
   /// \brief Find the intersection of two polygons, triangulating if either has any holes
   template<class T, template<class> class A>
   std::vector<Poly<T, A>>
-  union_polygons(const Poly<T, A> & a, const Poly<T, A> & b) {
+  polygons_union(const Poly<T, A> & a, const Poly<T, A> & b) {
     if (a.wires().wire_count() || b.wires().wire_count()){
-      return union_polygons(a.triangulate(), b.triangulate());
+      return networks_union(a.triangulate(), b.triangulate());
     }
-    return union_polygons(a.vertices(), a.wires().border(), b.vertices(), b.wires().border());
+    return wires_union(a.vertices(), a.wires().border(), b.vertices(), b.wires().border());
   }
 
   /// \brief Find the intersection of two triangulated polygon networks by considering all pairs of triangles
   template<class T, template<class> class A, class W=Wire>
   std::vector<Poly<T, A>>
-  union_polygons(const Network<W, T, A> & a, const Network<W, T, A> & b) {
+  networks_union(const Network<W, T, A> & a, const Network<W, T, A> & b) {
     std::vector<Poly<T, A>> result;
     result.reserve(std::max(a.size(), b.size()));
     for (const auto & wa: a.wires()) {
       for (const auto & wb: b.wires()) {
-        auto ps = union_polygons(a.vertices(), wa, b.vertices(), wb);
+        auto ps = wires_union(a.vertices(), wa, b.vertices(), wb);
         for (const auto & p: ps) if (p.area()) result.push_back(p);
       }
     }

--- a/src/polygon_wire.hpp
+++ b/src/polygon_wire.hpp
@@ -359,6 +359,30 @@ namespace polystar::polygon {
       return out;
     }
 
+    template<class T, class R, template<class> class A>
+    std::vector<bool> is_on(const A<R> & point, const A<T> & x) const {
+      std::vector<bool> out;
+      out.reserve(point.size(0));
+      for (ind_t i=0; i<point.size(0); ++i){
+        auto pi = point.view(i);
+        bool on_edge{false};
+        for (size_t j=0; j<size(); ++j){
+          auto e = edge(j);
+          auto a = x.view(e.first);
+          auto v0 = pi - a;
+          auto v1 = x.view(e.second) - a;
+          auto v0n = norm(v0).val(0, 0);
+          auto v1n = norm(v1).val(0, 0);
+          if (v0n == 0 || (cross2d(v0, v1).sum() == 0 && dot(v0, v1).val(0, 0) > 0  && v0n <= v1n)){
+            on_edge=true;
+            break;
+          }
+        }
+        out.push_back(on_edge);
+      }
+      return out;
+    }
+
     template<class T, template<class> class A>
     std::vector<size_t> crossing_number(const A<T> &point, const A<T> &x, end_type inclusive = end_type::second, bool verbose=false) const {
       std::vector<size_t> out;
@@ -410,7 +434,7 @@ namespace polystar::polygon {
     [[nodiscard]] T circumscribed_radius(const A<T> &x) const {
       auto c = centroid(x);
       T r{0};
-      for (const auto &i: *this) if (auto t = norm(c - x.view(i)); t > r) r = t;
+      for (const auto &i: *this) if (auto t = norm(c - x.view(i)).val(0,0); t > r) r = t;
       return r;
     }
 

--- a/src/tests/polygon_test.cpp
+++ b/src/tests/polygon_test.cpp
@@ -1,0 +1,79 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "array_.hpp"
+
+#include "polygon.hpp"
+
+using namespace polystar;
+using namespace polystar::polygon;
+
+TEST_CASE("Polygon area", "[polygon]"){
+  double h{2}, w{3};
+
+  std::vector<std::array<double,2>> va_vertices{{0, 0}, {0, h}, {w, h}, {w, 0}};
+  std::vector<ind_t> border{{0, 3, 2, 1}};
+
+  auto vertices = bArray<double>::from_std(va_vertices);
+  auto poly = Poly(vertices, static_cast<Wire>(border));
+
+  REQUIRE_THAT(poly.area(), Catch::Matchers::WithinRel(h*w, 1e-12));
+
+  auto hull = Poly(vertices); // w/o border information, the Convex Hull is found
+  REQUIRE_THAT(hull.area(), Catch::Matchers::WithinRel(h*w, 1e-12));
+  REQUIRE(poly == hull);
+
+  Wire ordered;
+  ordered.resize(vertices.size(0));
+  std::iota(ordered.begin(), ordered.end(), 0);
+  // force clockwise ordering of the vertices
+  auto inv_poly = Poly(vertices, ordered);
+  REQUIRE_THAT(inv_poly.area(), Catch::Matchers::WithinRel(-h*w, 1e-12));
+
+  std::vector<std::array<double, 2>> va_tri_vertices{{10, 20}, {20, 20}, {15, 30}};
+  auto tri_vertices = bArray<double>::from_std(va_tri_vertices);
+  auto triangle = Poly(tri_vertices);
+  REQUIRE_THAT(triangle.area(), Catch::Matchers::WithinRel(50, 1e-12));
+}
+
+
+TEST_CASE("Non-convex Polygon area", "[polygon]"){
+  std::vector<std::array<double, 2>> va_vertices{
+      {1, 1}, {2, 1}, {3, 2}, {4, 1},
+      {5, 1}, {5, 2}, {4, 3}, {5, 4},
+      {5, 5}, {4, 5}, {3, 4}, {2, 5},
+      {1, 5}, {1, 4}, {2, 3}, {1, 2}
+  };
+  auto vertices = bArray<double>::from_std(va_vertices);
+
+  Wire ordered;
+  ordered.resize(vertices.size(0));
+  std::iota(ordered.begin(), ordered.end(), 0);
+
+  auto poly = Poly(vertices, ordered);
+  auto hull = Poly(vertices);
+
+  SECTION("Area"){
+    REQUIRE_THAT(poly.area(), Catch::Matchers::WithinRel(12.0, 1e-12));
+    REQUIRE_THAT(hull.area(), Catch::Matchers::WithinRel(16.0, 1e-12));
+  }
+
+  SECTION("Centroid"){
+    auto centroid = poly.centroid();
+    REQUIRE_THAT(centroid.val(0, 0), Catch::Matchers::WithinRel(3., 1e-12));
+    REQUIRE_THAT(centroid.val(0, 1), Catch::Matchers::WithinRel(3., 1e-12));
+  }
+
+  SECTION("Intersection"){
+    auto overlap = polygon_intersection(poly, hull);
+    REQUIRE(overlap.size() == 1u);
+    REQUIRE(overlap[0] == poly);
+
+    auto o1 = poly.intersection(hull);
+    auto o2 = hull.intersection(poly);
+    REQUIRE(o1.size() == 1u);
+    REQUIRE(o2.size() == 1u);
+    REQUIRE(o1[0] == o2[0]);
+    REQUIRE(overlap[0] == o1[0]);
+  }
+}

--- a/src/tests/polygon_test.cpp
+++ b/src/tests/polygon_test.cpp
@@ -7,6 +7,7 @@
 
 using namespace polystar;
 using namespace polystar::polygon;
+using namespace Catch::Matchers;
 
 TEST_CASE("Polygon area", "[polygon]"){
   double h{2}, w{3};
@@ -17,10 +18,10 @@ TEST_CASE("Polygon area", "[polygon]"){
   auto vertices = bArray<double>::from_std(va_vertices);
   auto poly = Poly(vertices, static_cast<Wire>(border));
 
-  REQUIRE_THAT(poly.area(), Catch::Matchers::WithinRel(h*w, 1e-12));
+  REQUIRE_THAT(poly.area(), WithinRel(h*w, 1e-12));
 
   auto hull = Poly(vertices); // w/o border information, the Convex Hull is found
-  REQUIRE_THAT(hull.area(), Catch::Matchers::WithinRel(h*w, 1e-12));
+  REQUIRE_THAT(hull.area(), WithinRel(h*w, 1e-12));
   REQUIRE(poly == hull);
 
   Wire ordered;
@@ -28,12 +29,12 @@ TEST_CASE("Polygon area", "[polygon]"){
   std::iota(ordered.begin(), ordered.end(), 0);
   // force clockwise ordering of the vertices
   auto inv_poly = Poly(vertices, ordered);
-  REQUIRE_THAT(inv_poly.area(), Catch::Matchers::WithinRel(-h*w, 1e-12));
+  REQUIRE_THAT(inv_poly.area(), WithinRel(-h*w, 1e-12));
 
   std::vector<std::array<double, 2>> va_tri_vertices{{10, 20}, {20, 20}, {15, 30}};
   auto tri_vertices = bArray<double>::from_std(va_tri_vertices);
   auto triangle = Poly(tri_vertices);
-  REQUIRE_THAT(triangle.area(), Catch::Matchers::WithinRel(50, 1e-12));
+  REQUIRE_THAT(triangle.area(), WithinRel(50, 1e-12));
 }
 
 
@@ -54,14 +55,14 @@ TEST_CASE("Non-convex Polygon area", "[polygon]"){
   auto hull = Poly(vertices);
 
   SECTION("Area"){
-    REQUIRE_THAT(poly.area(), Catch::Matchers::WithinRel(12.0, 1e-12));
-    REQUIRE_THAT(hull.area(), Catch::Matchers::WithinRel(16.0, 1e-12));
+    REQUIRE_THAT(poly.area(), WithinRel(12.0, 1e-12));
+    REQUIRE_THAT(hull.area(), WithinRel(16.0, 1e-12));
   }
 
   SECTION("Centroid"){
     auto centroid = poly.centroid();
-    REQUIRE_THAT(centroid.val(0, 0), Catch::Matchers::WithinRel(3., 1e-12));
-    REQUIRE_THAT(centroid.val(0, 1), Catch::Matchers::WithinRel(3., 1e-12));
+    REQUIRE_THAT(centroid.val(0, 0), WithinRel(3., 1e-12));
+    REQUIRE_THAT(centroid.val(0, 1), WithinRel(3., 1e-12));
   }
 
   SECTION("Intersection"){
@@ -76,4 +77,92 @@ TEST_CASE("Non-convex Polygon area", "[polygon]"){
     REQUIRE(o1[0] == o2[0]);
     REQUIRE(overlap[0] == o1[0]);
   }
+}
+
+
+TEST_CASE("Edge intersection", "[polygon][edge]"){
+  std::vector<std::array<double, 2>> va_vertices {
+      {1, 1}, {2, 3}, {1, 3}, {4, 1}, {4, 3}, {2, 2}, {5, 0}, {1, 0}, {-2, -1}, {7, 5},
+      {-1, 0.25}, {1, 0.25}, {0.4, 0.4}, {0.4, -0.4}
+  };
+  auto vertices = bArray<double>::from_std(va_vertices);
+  SECTION("Mid-edge intersection"){
+    auto edge_1 = std::make_pair<ind_t, ind_t>(0, 1);
+    auto edge_2 = std::make_pair<ind_t, ind_t>(2, 3);
+    REQUIRE(intersect2d(vertices, edge_1, vertices, edge_2));
+    auto [flag, at] = intersection2d(vertices, edge_1, vertices, edge_2);
+    REQUIRE(flag == 1);
+    REQUIRE_THAT(at.val(0, 0), WithinRel(1.75, 1e-12));
+    REQUIRE_THAT(at.val(0, 1), WithinRel(2.5, 1e-12));
+  }
+  SECTION("Error-prone edge intersection"){
+    auto edge_1 = std::make_pair<ind_t, ind_t>(10, 11);
+    auto edge_2 = std::make_pair<ind_t, ind_t>(12, 13);
+    REQUIRE(intersect2d(vertices, edge_1, vertices, edge_2));
+    auto [flag, at] = intersection2d(vertices, edge_1, vertices, edge_2);
+    REQUIRE(flag == 1);
+    REQUIRE_THAT(at.val(0, 0), WithinRel(0.4, 1e-12));
+    REQUIRE_THAT(at.val(0, 1), WithinRel(0.25, 1e-12));
+  }
+  SECTION("Edge intersection at vertex"){
+    auto edge_1 = std::make_pair<ind_t, ind_t>(1, 0);
+    auto edge_2 = std::make_pair<ind_t, ind_t>(4, 0);
+    auto edge_1_reverse = std::make_pair(edge_1.second, edge_1.first);
+    auto edge_2_reverse = std::make_pair(edge_2.second, edge_2.first);
+    // An opinionated, and perhaps incorrect, choice was to exclude the first vertex of both edges
+    // from the possible intersection point.
+    REQUIRE(!intersect2d(vertices, edge_1_reverse, vertices, edge_2_reverse));
+    // Flipping one edge still doesn't find the intersection since the other first-vertex is excluded
+    REQUIRE(!intersect2d(vertices, edge_1_reverse, vertices, edge_2));
+    REQUIRE(!intersect2d(vertices, edge_1, vertices, edge_2_reverse));
+    // With the common vertex as the second in each edge, they are found to intersect
+    REQUIRE(intersect2d(vertices, edge_1, vertices, edge_2));
+    auto [flag, at] = intersection2d(vertices, edge_1, vertices, edge_2);
+    REQUIRE(flag == 1);
+    REQUIRE_THAT(at.val(0, 0), WithinRel(1., 1e-12));
+    REQUIRE_THAT(at.val(0, 1), WithinRel(1., 1e-12));
+    REQUIRE(at.row_is(cmp::eq, vertices.view(edge_2.second)).all());
+  }
+  SECTION("Edge no-intersection"){
+    // The infinite lines through segments
+    // {1, 1} -- {2, 3} and {2, 2} -- {5, 0}
+    // intersect, inside the first segment but outside the second.
+    auto edge_1 = std::make_pair<ind_t, ind_t>(0, 1);
+    auto edge_2 = std::make_pair<ind_t, ind_t>(5, 6);
+    REQUIRE(!intersect2d(vertices, edge_1, vertices, edge_2));
+    REQUIRE(!intersect2d(vertices, edge_2, vertices, edge_1));
+  }
+  SECTION("Parallel edges"){
+    auto edge_1 = std::make_pair<ind_t, ind_t>(0, 1);
+    auto edge_2 = std::make_pair<ind_t, ind_t>(5, 7);
+    REQUIRE(!intersect2d(vertices, edge_1, vertices, edge_2));
+  }
+  SECTION("Colinear edges"){
+    auto edge_1 = std::make_pair<ind_t, ind_t>(0, 4);
+    auto edge_2 = std::make_pair<ind_t, ind_t>(8, 9);
+    REQUIRE(intersect2d(vertices, edge_1, vertices, edge_2));
+    REQUIRE(intersect2d(vertices, edge_2, vertices, edge_1));
+    auto [flag, at] = intersection2d(vertices, edge_1, vertices, edge_2);
+    REQUIRE(flag == 2);
+    // at contains both vertices of edge_1
+    REQUIRE(at.row_is(cmp::eq, vertices.view(edge_1.first)).sum() == 1);
+    REQUIRE(at.row_is(cmp::eq, vertices.view(edge_1.second)).sum() == 1);
+  }
+
+}
+
+TEST_CASE("Rectangle intersection"){
+  std::vector<std::array<double, 2>> va_vertices_1{{0, 0}, {2, 0}, {2, 2}, {0, 2}};
+  std::vector<std::array<double, 2>> va_vertices_2{{1, 1}, {3, 1}, {3, 3}, {1, 3}};
+  std::vector<std::array<double, 2>> va_vertices_r{{1, 1}, {2, 1}, {2, 2}, {1, 2}};
+  auto vertices_1 = bArray<double>::from_std(va_vertices_1);
+  auto vertices_2 = bArray<double>::from_std(va_vertices_2);
+  auto vertices_r = bArray<double>::from_std(va_vertices_r);
+  auto poly_1 = Poly(vertices_1);
+  auto poly_2 = Poly(vertices_2);
+  auto poly_r = Poly(vertices_r);
+  auto result = polygon_intersection(poly_1, poly_2);
+  REQUIRE(result.size() == 1u);
+  REQUIRE_THAT(result[0].area(), WithinRel(1., 1e-12));
+  REQUIRE(poly_r == result[0].without_extraneous_vertices());
 }

--- a/wrap/_polygon.hpp
+++ b/wrap/_polygon.hpp
@@ -85,8 +85,8 @@ void define_polygon(py::class_<A> & cls){
 // overloaded operations:
   cls.def("__eq__", [](const A& p, const A& o){return p == o;});
   cls.def("__neq__", [](const A& p, const A& o){return p != o;});
-  cls.def("__add__", [](const A& p, const A& o){return p + o;});
-  cls.def("__add__", [](const A& p, const std::vector<A> & v){return p.combine_all(v);});
+//  cls.def("__add__", [](const A& p, const A& o){return p + o;});
+//  cls.def("__add__", [](const A& p, const std::vector<A> & v){return p.combine_all(v);});
 
 }
 //


### PR DESCRIPTION
Fixes #4 by implementing the Weiler-Atherton algorithm for counter-clockwise ordered vertex polygons.

Test cases are added to the binary test target which exercise polygon creation, line-segment intersection detection, concave and convex polygon intersections.
There are, however, undoubtedly edge cases which are not tested.