### PR TITLE
Bump cibuildwheel version

### DIFF
--- a/.github/workflows/package_deploy.yml
+++ b/.github/workflows/package_deploy.yml
@@ -51,7 +51,7 @@ jobs:
         python-version: 3.8
       if: runner.os == 'macOS' && runner.arch == 'ARM64'
 
-    - uses: pypa/cibuildwheel@v2.19.2
+    - uses: pypa/cibuildwheel@v2.20.0
       env:
         CIBW_BUILD: "*-${{ matrix.variant.platform }}*"
         MACOSX_DEPLOYMENT_TARGET: "10.15"


### PR DESCRIPTION
Update cibuildwheel to use v2.20.0 which enables Python 3.13 wheels without any extra flags.