### PR TITLE
Reenable wheels for Arm macOS and Windows

### DIFF
--- a/.github/workflows/package_deploy.yml
+++ b/.github/workflows/package_deploy.yml
@@ -36,10 +36,11 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - {os: ubuntu-22.04, platform: 'manylinux'}
-          - {os: ubuntu-22.04, platform: 'musllinux'}
-          - {os: macos-13, platform: 'macosx'}      # Intel support
-#          - {os: macos-latest, platform: 'macosx'}  # Apple silicon support
+          - { os: ubuntu-22.04, platform: 'manylinux' }
+          - { os: ubuntu-22.04, platform: 'musllinux' }
+          - { os: macos-13, platform: 'macosx' }  # Intel support
+          - { os: macos-14, platform: 'macosx' }  # Apple silicon support
+          - { os: windows-2022, platform: "win" }
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
All CMake builds and tests pass. Testing the wheel creation will require making a new release.